### PR TITLE
Clean up file connections on mocked POST/PUT

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Depends:
     R (>= 3.0.0),
     testthat
 Imports:
+    curl,
     digest,
     httr,
     jsonlite,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,8 +13,11 @@ Description: Testing and documenting code that communicates with remote servers
     test fixtures. The ability to save responses and load them offline also
     enables one to write vignettes and other dynamic documents that can be
     distributed without access to a live server.
-Version: 3.3.0
-Authors@R: person("Neal", "Richardson", role=c("aut", "cre"), email="neal.p.richardson@gmail.com")
+Version: 3.3.0.9000
+Authors@R: c(
+        person("Neal", "Richardson", role=c("aut", "cre"), email="neal.p.richardson@gmail.com"),
+        person("Jonathan", "Keane", role="ctb", email="jkeane@gmail.com")
+    )
 URL: https://enpiar.com/r/httptest, https://github.com/nealrichardson/httptest
 BugReports: https://github.com/nealrichardson/httptest/issues
 License: MIT + file LICENSE

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# httptest 3.3.0.9000 (under development)
+* Mocking PUT and POST with a body consisting of only `httr::upload_file` no longer leaves a file connection open. 
+
 # httptest 3.3.0
 
 * (Re)load package redactors when loading a package interactively with `pkgload::load_all()`, formerly of `devtools` (#15)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * (Re)load package redactors when loading a package interactively with `pkgload::load_all()`, formerly of `devtools` (#15)
 * `expect_header()` now defaults to `ignore.case=TRUE` because HTTP header names are case insensitive. 
+* File uploads with `httr::upload_file` are now mockable even when tests are run from different locations.
 
 # httptest 3.2.2
 

--- a/R/trace.R
+++ b/R/trace.R
@@ -54,7 +54,7 @@ quietly <- function (expr) {
 #' @return Nothing; called for its side effects
 #' @export
 stop_mocking <- function () {
-    untrace(curl::form_file)
+    quietly(untrace(curl::form_file))
     invisible(safe_untrace("request_perform", add_headers))
 }
 

--- a/R/trace.R
+++ b/R/trace.R
@@ -21,7 +21,7 @@ mock_perform <- function (mocker, ...) {
     # trace curl's form_file making the path normalization a no-op so that file
     # hashes are the same on different platforms
     trace(curl::form_file, quote(
-        normalizePath <- function (path, ...) { return(path) }
+        normalizePath <- function (path, ...) return(path)
     ), where=httr::upload_file, print=getOption("httptest.debug", FALSE))
 
     invisible(trace_httr("request_perform", tracer=tracer, ...))
@@ -54,7 +54,7 @@ quietly <- function (expr) {
 #' @return Nothing; called for its side effects
 #' @export
 stop_mocking <- function () {
-    quietly(untrace(curl::form_file))
+    safe_untrace(untrace(curl::form_file))
     invisible(safe_untrace("request_perform", add_headers))
 }
 

--- a/R/trace.R
+++ b/R/trace.R
@@ -20,9 +20,9 @@ mock_perform <- function (mocker, ...) {
     tracer <- substitute_q(fetch_tracer, list(.mocker=mocker))
     # trace curl's form_file making the path normalization a no-op so that file
     # hashes are the same on different platforms
-    quietly(trace(curl::form_file, quote(
-        normalizePath <- function(path, ...) { return(path) }
-    ), where = httr::upload_file))
+    trace(curl::form_file, quote(
+        normalizePath <- function (path, ...) { return(path) }
+    ), where=httr::upload_file, print=getOption("httptest.debug", FALSE))
 
     invisible(trace_httr("request_perform", tracer=tracer, ...))
 }

--- a/R/trace.R
+++ b/R/trace.R
@@ -23,6 +23,11 @@ mock_perform <- function (mocker, ...) {
     trace(curl::form_file, quote(
         normalizePath <- function (path, ...) return(path)
     ), where=httr::upload_file, print=getOption("httptest.debug", FALSE))
+    # trace body_config to close the file connection that it creates when the
+    # body inherits form_file
+    trace("body_config", exit=quote(
+        if (exists("con")) close.connection(con)
+    ), where=httr::PUT)
 
     invisible(trace_httr("request_perform", tracer=tracer, ...))
 }

--- a/R/trace.R
+++ b/R/trace.R
@@ -18,6 +18,12 @@ with_trace <- function (x, where=topenv(parent.frame()), print=getOption("httpte
 
 mock_perform <- function (mocker, ...) {
     tracer <- substitute_q(fetch_tracer, list(.mocker=mocker))
+    # trace curl's form_file making the path normalization a no-op so that file
+    # hashes are the same on different platforms
+    quietly(trace(curl::form_file, quote(
+        normalizePath <- function(path, ...) { return(path) }
+    ), where = httr::upload_file))
+
     invisible(trace_httr("request_perform", tracer=tracer, ...))
 }
 
@@ -48,6 +54,7 @@ quietly <- function (expr) {
 #' @return Nothing; called for its side effects
 #' @export
 stop_mocking <- function () {
+    untrace(curl::form_file)
     invisible(safe_untrace("request_perform", add_headers))
 }
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -18,6 +18,7 @@ httr
 json
 JSON
 Makefile
+mockable
 mock's
 munge
 OAuth

--- a/tests/testthat/test-mock-api.R
+++ b/tests/testthat/test-mock-api.R
@@ -100,13 +100,12 @@ public({
                 'http://httpbin.org/post',
                 '{"x":"A simple text string"} ',
                 '(httpbin.org/post-34199a-POST.json)')
-            skip("Need to find a platform-independent way to hash the filename")
             expect_POST(POST(b2, body = list(y = upload_file("helper.R"))),
                 'http://httpbin.org/post',
                 'list(y = list(path = "',
-                normalizePath("helper.R"),
+                "helper.R",
                 '", type = "text/plain")) ',
-                '(httpbin.org/post-78d84e-POST.json)')
+                '(httpbin.org/post-519188-POST.json)')
         })
 
         test_that("Regular expressions in expect_VERB", {

--- a/tests/testthat/test-mock-api.R
+++ b/tests/testthat/test-mock-api.R
@@ -108,6 +108,23 @@ public({
                 '(httpbin.org/post-519188-POST.json)')
         })
 
+        test_that("PUT/POST with only a upload_file in body", {
+            b1 <- "http://httpbin.org/post"
+            expect_POST(POST(b1, body = upload_file("helper.R")),
+                'http://httpbin.org/post',
+                '(httpbin.org/post-POST.json)')
+            # and ensure that there are no floating connections still open
+            open_conns <- showConnections()
+            expect_false(any(open_conns[, "description"] == "helper.R"))
+            b2 <- "http://httpbin.org/put"
+            expect_PUT(PUT(b2, body = upload_file("helper.R")),
+                'http://httpbin.org/put',
+                '(httpbin.org/put-PUT.json)')
+            # and ensure that there are no floating connections still open
+            open_conns <- showConnections()
+            expect_false(any(open_conns[, "description"] == "helper.R"))
+        })
+
         test_that("Regular expressions in expect_VERB", {
             expect_GET(GET("http://example.com/1234/abcd/"),
                 "http://example.com/[0-9]{4}/[a-z]{4}/",


### PR DESCRIPTION
When the body of the request is only a `form_file` (e.g. `PUT(url, body = upload_file("./file"))`), a connection [is opened to the file in `body_config()`](https://github.com/r-lib/httr/blob/af25ebd0e3b72d2dc6e1423242b94efc25bc97cc/R/body.R#L10-L11) which is not closed until [`curl::curl_fetch_memory()`](https://github.com/r-lib/httr/blob/af25ebd0e3b72d2dc6e1423242b94efc25bc97cc/R/write-function.R#L79) is called during `request_perform()`. When using a mocked API, `curl::curl_fetch_memory()` isn't called, so the connection remains open leading to warnings (typically at the end of the test suite).