### PR TITLE
Default .mockPaths() prefers to be in tests/testthat

### DIFF
--- a/R/mock-paths.R
+++ b/R/mock-paths.R
@@ -26,7 +26,7 @@
 #' @rdname mockPaths
 #' @export
 .mockPaths <- function (new) {
-    current <- getOption("httptest.mock.paths", default=".")
+    current <- getOption("httptest.mock.paths", default=testthat::test_path())
     if (missing(new)) {
         ## We're calling the function to get the list of paths
         return(current)

--- a/R/mock-paths.R
+++ b/R/mock-paths.R
@@ -26,7 +26,7 @@
 #' @rdname mockPaths
 #' @export
 .mockPaths <- function (new) {
-    current <- getOption("httptest.mock.paths", default=testthat::test_path())
+    current <- getOption("httptest.mock.paths", default=default_mock_path())
     if (missing(new)) {
         ## We're calling the function to get the list of paths
         return(current)
@@ -40,6 +40,14 @@
         options(httptest.mock.paths=current)
         invisible(current)
     }
+}
+
+default_mock_path <- function() {
+  if (dir.exists("tests/testthat")) {
+    "tests/testthat"
+  } else {
+    "."
+  }
 }
 
 with_mock_path <- function (path, expr, replace=FALSE) {

--- a/tests/testthat/test-mock-paths.R
+++ b/tests/testthat/test-mock-paths.R
@@ -10,6 +10,15 @@ public({
         expect_identical(.mockPaths(), ".")
     })
 
+    test_that(".mockPaths default path prefers to be in tests/testthat", {
+        d <- tempfile()
+        dir.create(file.path(d, "tests", "testthat"), recursive=TRUE)
+        old <- setwd(d)
+        on.exit(setwd(old))
+
+        expect_identical(.mockPaths(), "tests/testthat")
+    })
+
     with_mock_api({
         test_that("GET with no query, default mock path", {
             b <- GET("api/object1/")


### PR DESCRIPTION
Fixes #50 

I went with a narrower solution than we discussed on #50: only the default path uses test_path(). This should support the use cases of:

```r
devtools::load_all()
use_mock_api()
# ... do interactive testing
```

and 

```r
devtools::load_all()
start_capturing()
# ... do interactive requests
```

but doesn't otherwise add complexity in trying to guess whether a path should be relative to the current working directory, or to `tests/testthat`, or to `vignettes`, or if it should be absolute.

@maelle what do you think?