### PR TITLE
Fix condition expectations in prevision of testthat breaking change

### DIFF
--- a/tests/testthat/test-fake-http.R
+++ b/tests/testthat/test-fake-http.R
@@ -115,15 +115,15 @@ test_that("fake_response returns a valid enough response even if you give it jus
 })
 
 test_that("fake_request gets covered directly (not just in tracer)", {
-  expect_s3_class(
-    expect_message(
+  expect_message(
+    expect_s3_class(
       fake_request(list(method = "GET", url = "http://httpbin.org/get")),
-      "GET http://httpbin.org/get"
+      "response"
     ),
-    "response"
+    "GET http://httpbin.org/get"
   )
-  expect_s3_class(
-    expect_message(
+  expect_message(
+    expect_s3_class(
       fake_request(
         list(
           method = "POST",
@@ -131,8 +131,8 @@ test_that("fake_request gets covered directly (not just in tracer)", {
           options = list(postfields = charToRaw("body"))
         )
       ),
-      "POST http://httpbin.org/get body"
+      "response"
     ),
-    "response"
+    "POST http://httpbin.org/get body"
   )
 })


### PR DESCRIPTION
We are planning a breaking change to the condition expectations in testthat release (see NEWS item in https://github.com/r-lib/testthat/pull/1401). This PR implements a preventive fix that works with and without the breaking change.

There is no hurry to get this fix on CRAN since we are skipping one released version of testthat before going through with the change.
