### PR TITLE
Add comment to clarify without_internet usage in an example

### DIFF
--- a/R/expect-request.R
+++ b/R/expect-request.R
@@ -27,6 +27,7 @@
 #' @return A `testthat` 'expectation'.
 #' @examples
 #' library(httr)
+#' # without_internet provides required mock context for expectations
 #' without_internet({
 #'   expect_GET(
 #'     GET("http://httpbin.org/get"),

--- a/R/expect-request.R
+++ b/R/expect-request.R
@@ -1,5 +1,6 @@
 #' Expectations for mocked HTTP requests
 #'
+#' @description
 #' The mock contexts in `httptest` can raise errors or messages when requests
 #' are made, and those (error) messages have three
 #' elements, separated by space: (1) the request
@@ -7,6 +8,11 @@
 #' (3) the request body, if present.
 #' These verb-expectation functions look for this message shape. `expect_PUT`,
 #' for instance, looks for a request message that starts with "PUT".
+#'
+#' This means that `expect_verb` functions won't work outside of mock context,
+#' as no error would be raised while making a request. Thus, any `expect_verb`
+#' function should be wrapped inside a mocking function like
+#' [without_internet()], as shown in the examples.
 #'
 #' @param object Code to execute that may cause an HTTP request
 #' @param url character: the URL you expect a request to be made to. Default is

--- a/man/expect_verb.Rd
+++ b/man/expect_verb.Rd
@@ -55,6 +55,11 @@ method (e.g. "GET"); (2) the request URL; and
 (3) the request body, if present.
 These verb-expectation functions look for this message shape. \code{expect_PUT},
 for instance, looks for a request message that starts with "PUT".
+
+This means that \code{expect_verb} functions won't work outside of mock context,
+as no error would be raised while making a request. Thus, any \code{expect_verb}
+function should be wrapped inside a mocking function like
+\code{\link[=without_internet]{without_internet()}}, as shown in the examples.
 }
 \examples{
 library(httr)

--- a/man/expect_verb.Rd
+++ b/man/expect_verb.Rd
@@ -58,6 +58,7 @@ for instance, looks for a request message that starts with "PUT".
 }
 \examples{
 library(httr)
+# without_internet provides required mock context for expectations
 without_internet({
   expect_GET(
     GET("http://httpbin.org/get"),

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -63,8 +63,7 @@ install_testpkg <- function(pkg, lib = tempfile()) {
 }
 
 skip_on_R_older_than <- function(version) {
-  r <- R.Version()
-  if (utils::compareVersion(paste(r$major, r$minor, sep = "."), version) < 0) {
+  if (getRversion() < version) {
     skip(paste("Requires R >=", version))
   }
 }


### PR DESCRIPTION
Related to issue #67 I made earlier. Added a comment to the examples that clarifies why `without_internet()` was used. I thought that function was added to avoid making internet calls in examples (which was a problem when I co-submitted a certain package to CRAN); the comment should clear any possible confusion from people that skip past the title and the description straight to the examples...