### PR TITLE
stop_mocking() should untrace all functions (closes #66, #78)

### DIFF
--- a/R/trace.R
+++ b/R/trace.R
@@ -61,8 +61,10 @@ quietly <- function(expr) {
 #' @return Nothing; called for its side effects
 #' @export
 stop_mocking <- function() {
-  safe_untrace(curl::form_file)
-  invisible(safe_untrace("request_perform", add_headers))
+  safe_untrace("request_perform", add_headers)
+  safe_untrace("body_config", getNamespace("httr"))
+  safe_untrace("form_file", getNamespace("curl"))
+  invisible()
 }
 
 safe_untrace <- function(what, where = sys.frame()) {

--- a/R/trace.R
+++ b/R/trace.R
@@ -61,7 +61,7 @@ quietly <- function(expr) {
 #' @return Nothing; called for its side effects
 #' @export
 stop_mocking <- function() {
-  safe_untrace("request_perform", add_headers)
+  safe_untrace("request_perform", getNamespace("httr"))
   safe_untrace("body_config", getNamespace("httr"))
   safe_untrace("form_file", getNamespace("curl"))
   invisible()

--- a/tests/testthat/.gitignore
+++ b/tests/testthat/.gitignore
@@ -1,0 +1,1 @@
+.httr-oauth

--- a/tests/testthat/test-mock-api.R
+++ b/tests/testthat/test-mock-api.R
@@ -213,16 +213,6 @@ public({
     })
   })
 
-  # check that the functions are untraced
-  expect_false(inherits(httr:::body_config, "functionWithTrace"))
-  expect_false(inherits(curl::form_file, "functionWithTrace"))
-  expect_false(inherits(httr:::request_perform, "functionWithTrace"))
-  for (verb in c("GET", "PUT", "POST", "PATCH", "DELETE", "VERB", "RETRY")) {
-    fun <- getFromNamespace(verb, 'httr')
-    expect_false(inherits(fun, "functionWithTrace"))
-  }
-
-
 })
 
 test_that("build_mock_url file path construction with character URL", {

--- a/tests/testthat/test-mock-api.R
+++ b/tests/testthat/test-mock-api.R
@@ -212,6 +212,17 @@ public({
       )
     })
   })
+
+  # check that the functions are untraced
+  expect_false(inherits(httr:::body_config, "functionWithTrace"))
+  expect_false(inherits(curl::form_file, "functionWithTrace"))
+  expect_false(inherits(httr:::request_perform, "functionWithTrace"))
+  for (verb in c("GET", "PUT", "POST", "PATCH", "DELETE", "VERB", "RETRY")) {
+    fun <- getFromNamespace(verb, 'httr')
+    expect_false(inherits(fun, "functionWithTrace"))
+  }
+
+
 })
 
 test_that("build_mock_url file path construction with character URL", {

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -33,7 +33,7 @@ public({
   })
 
   test_that("curl/httr functions are properly untraced", {
-      expect_true(all(!.are_pkgs_traced()))
+      expect_false(any(.are_pkgs_traced()))
   })
 
 })

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -10,6 +10,36 @@ public({
     expect_error(stop_capturing(), NA)
     expect_error(stop_capturing(), NA)
   })
+
+  FUNS <- list(
+    httr = c('GET', 'PUT', 'POST', 'PATCH', 'DELETE', 'VERB', 'RETRY', 'request_perform', 'body_config'),
+    curl = c('form_file')
+  )
+  
+  .are_pkgs_traced <- function() {
+    .process_fun <- function(fun, pkg) {
+      inherits(getFromNamespace(fun, pkg), "functionWithTrace")
+    }
+    .process_pkg <- function(pkg) {
+      sapply(FUNS[[pkg]], .process_fun, pkg = pkg)
+    }
+    unlist(lapply(names(FUNS), .process_pkg))
+  }
+
+  with_mock_api({
+    test_that("cur/httr functions are properly traced", {
+      browser()
+      expect_true(all(.are_pkgs_traced()))
+    })
+  })
+
+  # test_that("cur/httr functions are properly untraced", {
+  #   for (fun_name in TRACED_FUNCTIONS) {
+  #     fun <- getFromNamespace(fun_name, 'httr')
+  #     expect_false(inherits(fun, "functionWithTrace"))
+  #   }
+  # })
+
 })
 
 test_that("quietly muffles messages, conditional on httptest.debug", {

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -12,7 +12,7 @@ public({
   })
 
   FUNS <- list(
-    httr = c('GET', 'PUT', 'POST', 'PATCH', 'DELETE', 'VERB', 'RETRY', 'request_perform', 'body_config'),
+    httr = c('request_perform', 'body_config'),
     curl = c('form_file')
   )
   
@@ -27,18 +27,14 @@ public({
   }
 
   with_mock_api({
-    test_that("cur/httr functions are properly traced", {
-      browser()
+    test_that("curl/httr functions are properly traced", {
       expect_true(all(.are_pkgs_traced()))
     })
   })
 
-  # test_that("cur/httr functions are properly untraced", {
-  #   for (fun_name in TRACED_FUNCTIONS) {
-  #     fun <- getFromNamespace(fun_name, 'httr')
-  #     expect_false(inherits(fun, "functionWithTrace"))
-  #   }
-  # })
+  test_that("curl/httr functions are properly untraced", {
+      expect_true(all(!.are_pkgs_traced()))
+  })
 
 })
 


### PR DESCRIPTION
fixed stop_mocking() that did not untrace all functionstly called safe_untrace. Added corresponding tests. Should fix issue #78 and #66.